### PR TITLE
Fix build with Java 20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
 
     <properties>
         <quarkus.version>3.0.1.Final</quarkus.version>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Sets the javac release option to 11, sets the source encoding to UTF-8.